### PR TITLE
Fixed the restart button in mobile phone

### DIFF
--- a/style.css
+++ b/style.css
@@ -180,6 +180,10 @@ footer {
         min-width: 44px;
         min-height: 44px;
     }
+    #new-game-btn {
+        position:static;
+        margin-bottom: 24px;
+    }
 }
 
 @media (max-width: 360px) {


### PR DESCRIPTION
<img width="399" height="862" alt="image" src="https://github.com/user-attachments/assets/e5a8216f-35d0-4f5f-af84-9b4abff6437f" />
Here's the image of the update that fixes the position of the restart button for the mobile phones which was overlapping the title earlier